### PR TITLE
Fix intersection

### DIFF
--- a/Set/Set.swift
+++ b/Set/Set.swift
@@ -70,7 +70,7 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 	public func intersection(set: Set) -> Set {
 		return self.count <= set.count ?
 			filter { set.contains($0) }
-		:	filter { self.contains($0) }
+		:	set.filter { self.contains($0) }
 	}
 
 	/// Returns a new set with all elements from the receiver which are not contained in `set`.

--- a/Set/Set.swift
+++ b/Set/Set.swift
@@ -38,7 +38,7 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 	}
 
 
-	// MARK: Primitive methods
+	// MARK: Primitive operations
 
 	/// True iff `element` is in the receiver, as defined by its hash and equality.
 	public func contains(element: Element) -> Bool {

--- a/Set/Set.swift
+++ b/Set/Set.swift
@@ -244,11 +244,7 @@ public func -= <Element> (inout set: Set<Element>, other: Set<Element>) {
 
 /// Intersects with `set` with `other`.
 public func &= <Element> (inout set: Set<Element>, other: Set<Element>) {
-	for element in set {
-		if !other.contains(element) {
-			set.remove(element)
-		}
-	}
+	set = set.intersection(other)
 }
 
 /// Returns the intersection of `set` and `other`.

--- a/Set/Set.swift
+++ b/Set/Set.swift
@@ -161,8 +161,10 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 
 	/// Inserts each element of `sequence` into the receiver.
 	public mutating func extend<S: SequenceType where S.Generator.Element == Element>(sequence: S) {
-		// Note that this should just be for each in sequence; this is working around a compiler crasher.
-		for each in [Element](sequence) {
+		// Note that this should just be for each in sequence; this is working around a compiler bug.
+		var generator = sequence.generate()
+		let next: () -> Element? = { generator.next() }
+		for each in GeneratorOf(next) {
 			insert(each)
 		}
 	}

--- a/Set/Set.swift
+++ b/Set/Set.swift
@@ -105,7 +105,7 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 	// MARK: Higher-order functions
 
 	/// Returns a new set including only those elements `x` where `includeElement(x)` is true.
-	public func filter(includeElement: (Element) -> Bool) -> Set<Element> {
+	public func filter(includeElement: (Element) -> Bool) -> Set {
 		return Set(Swift.filter(self, includeElement))
 	}
 
@@ -157,7 +157,7 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 	// MARK: ExtensibleCollectionType
 
 	/// In theory, reserve capacity for `n` elements. However, Dictionary does not implement reserveCapacity(), so we just silently ignore it.
-	public func reserveCapacity(n: Set<Element>.Index.Distance) {}
+	public func reserveCapacity(n: Set.Index.Distance) {}
 
 	/// Inserts each element of `sequence` into the receiver.
 	public mutating func extend<S: SequenceType where S.Generator.Element == Element>(sequence: S) {

--- a/Set/Set.swift
+++ b/Set/Set.swift
@@ -105,7 +105,7 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 	// MARK: Higher-order functions
 
 	/// Returns a new set including only those elements `x` where `includeElement(x)` is true.
-	public func filter(includeElement: (Element) -> Bool) -> Set {
+	public func filter(includeElement: Element -> Bool) -> Set {
 		return Set(Swift.filter(self, includeElement))
 	}
 

--- a/Set/Set.swift
+++ b/Set/Set.swift
@@ -236,9 +236,7 @@ public func - <Element> (set: Set<Element>, other: Set<Element>) -> Set<Element>
 
 /// Removes all elements in `other` from `set`.
 public func -= <Element> (inout set: Set<Element>, other: Set<Element>) {
-	for element in other {
-		set.remove(element)
-	}
+	set = set.difference(other)
 }
 
 

--- a/Set/Set.swift
+++ b/Set/Set.swift
@@ -2,6 +2,7 @@
 
 /// A set of unique elements as determined by `hashValue` and `==`.
 public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollectionType, Hashable, Printable, DebugPrintable {
+
 	// MARK: Constructors
 
 	/// Constructs a `Set` with the elements of `sequence`.
@@ -58,6 +59,7 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 	public mutating func removeAll() {
 		values = [:]
 	}
+
 
 	// MARK: Algebraic operations
 
@@ -203,6 +205,7 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 			"{" + join(", ", map(toString)) + "}"
 		:	"{}"
 	}
+
 
 	// MARK: DebugPrintable
 	

--- a/SetTests/SetOperationTests.swift
+++ b/SetTests/SetOperationTests.swift
@@ -17,6 +17,8 @@ class SetOperationTests: XCTestCase {
 
 	func testIntersection() {
 		XCTAssert(Set(1, 2, 3) & Set(2, 3, 4) == Set(2, 3))
+		XCTAssert(Set(2, 3) & Set(1, 2, 3, 4) == Set(2, 3))
+		XCTAssert(Set(1, 2, 3, 4) & Set(2, 3) == Set(2, 3))
 	}
 
 	func testIntersectionAssignment() {


### PR DESCRIPTION
Intersecting a set with a shorter set was broken.

This PR corrects that, optimizes extend(), and uses a single code path for the difference/intersection operators, whether assigning or returning.

I also took the opportunity to make misc. style changes.