### PR TITLE
Filter lazily.

### DIFF
--- a/Set/Set.swift
+++ b/Set/Set.swift
@@ -108,7 +108,7 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 
 	/// Returns a new set including only those elements `x` where `includeElement(x)` is true.
 	public func filter(includeElement: Element -> Bool) -> Set {
-		return Set(Swift.filter(self, includeElement))
+		return Set(lazy(self).filter(includeElement))
 	}
 
 	/// Returns a new set with the result of applying `transform` to each element.


### PR DESCRIPTION
In tests filtering a 3-set 10,000 times with { _ in true }, the lazy version took ⅔ to ½ the time that the previous strict version took.

Fixes #26.