### PR TITLE
Differences and complements

### DIFF
--- a/Set/Set.swift
+++ b/Set/Set.swift
@@ -82,6 +82,13 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 		return filter { !set.contains($0) }
 	}
 
+	/// Returns the symmetric difference of `self` and `set`.
+	///
+	/// This is a new set with all elements that exist only in `self` or `set`, and not both.
+	public func difference(set: Set) -> Set {
+		return union(set) - intersection(set)
+	}
+
 
 	// MARK: Set inclusion functions
 

--- a/Set/Set.swift
+++ b/Set/Set.swift
@@ -75,8 +75,10 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 		:	set.filter { self.contains($0) }
 	}
 
-	/// Returns a new set with all elements from the receiver which are not contained in `set`.
-	public func difference(set: Set) -> Set {
+	/// Returns the relative complement of `set` in `self`.
+	///
+	/// This is a new set with all elements from the receiver which are not contained in `set`.
+	public func complement(set: Set) -> Set {
 		return filter { !set.contains($0) }
 	}
 
@@ -85,7 +87,7 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 
 	/// True iff the receiver is a subset of (is included in) `set`.
 	public func subset(set: Set) -> Bool {
-		return difference(set) == Set()
+		return complement(set) == Set()
 	}
 
 	/// True iff the receiver is a subset of but not equal to `set`.
@@ -236,12 +238,12 @@ public func += <S: SequenceType> (inout set: Set<S.Generator.Element>, sequence:
 
 /// Returns a new set with all elements from `set` which are not contained in `other`.
 public func - <Element> (set: Set<Element>, other: Set<Element>) -> Set<Element> {
-	return set.difference(other)
+	return set.complement(other)
 }
 
 /// Removes all elements in `other` from `set`.
 public func -= <Element> (inout set: Set<Element>, other: Set<Element>) {
-	set = set.difference(other)
+	set = set.complement(other)
 }
 
 

--- a/SetTests/SetOperationTests.swift
+++ b/SetTests/SetOperationTests.swift
@@ -38,4 +38,8 @@ class SetOperationTests: XCTestCase {
 
 		XCTAssert(set == Set(1))
 	}
+
+	func testDifference() {
+		XCTAssert(Set(1, 2, 3).difference(Set(2, 3, 4)) == Set(1, 4))
+	}
 }

--- a/SetTests/SetOperationTests.swift
+++ b/SetTests/SetOperationTests.swift
@@ -28,11 +28,11 @@ class SetOperationTests: XCTestCase {
 		XCTAssert(set == Set(2, 3))
 	}
 	
-	func testDifference() {
+	func testComplement() {
 		XCTAssert(Set(1, 2, 3) - Set(2, 3, 4) == Set(1))
 	}
 
-	func testDifferenceAssignment() {
+	func testComplementAssignment() {
 		var set = Set(1, 2, 3)
 		set -= Set(2, 3, 4)
 


### PR DESCRIPTION
This renames the extant `difference` method to `complement` and adds a new `difference` method which constructs the symmetric difference correctly.

The - operator continues to mean the complement (as it always had), so backwards-compatibility issues are expected to be minimal given that the operator is typically more convenient than the method. I’m intending to release and tag a new minor version following the merging of this PR, i.e. 1.x rather than 2.0.

- Fixes #4.
- Fixes #29.