### PR TITLE
Distributive debug description

### DIFF
--- a/Set/Set.swift
+++ b/Set/Set.swift
@@ -210,7 +210,9 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 	// MARK: DebugPrintable
 	
 	public var debugDescription: String {
-		return description
+		return count > 0 ?
+			"{" + join(", ", map(toDebugString)) + "}"
+		:	"{}"
 	}
 	
 

--- a/Set/Set.swift
+++ b/Set/Set.swift
@@ -202,7 +202,7 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 
 	public var description: String {
 		return count > 0 ?
-			"{" + join(", ", map(toString)) + "}"
+			"{" + join(", ", lazy(self).map(toString)) + "}"
 		:	"{}"
 	}
 
@@ -211,7 +211,7 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 	
 	public var debugDescription: String {
 		return count > 0 ?
-			"{" + join(", ", map(toDebugString)) + "}"
+			"{" + join(", ", lazy(self).map(toDebugString)) + "}"
 		:	"{}"
 	}
 	

--- a/SetTests/SetPrintableTests.swift
+++ b/SetTests/SetPrintableTests.swift
@@ -3,14 +3,28 @@
 import XCTest
 import Set
 
-class SetPrintableTests: XCTestCase {
+class SetPrintableTests: XCTestCase, Printable, DebugPrintable {
 	func testDescription() {
 		XCTAssertEqual(Set<Int>().description, "{}")
-		XCTAssertEqual(Set(1).description, "{1}")
+		XCTAssertEqual(Set(self).description, "{description}")
 	}
 
 	func testDebugDescription() {
 		XCTAssertEqual(Set<Int>().debugDescription, "{}")
-		XCTAssertEqual(Set(1).debugDescription, "{1}")
+		XCTAssertEqual(Set(self).debugDescription, "{debugDescription}")
+	}
+
+
+	// MARK: Printable
+
+	override var description: String {
+		return __FUNCTION__
+	}
+
+
+	// MARK: DebugPrintable
+
+	override var debugDescription: String {
+		return __FUNCTION__
 	}
 }


### PR DESCRIPTION
Previously, `debugDescription` was just returning `description`, and therefore using `toString`.

In this PR, it uses `toDebugString` instead, distributing the debug-ness of the requested string over the elements.