### PR TITLE
Multisets

### DIFF
--- a/Set.xcodeproj/project.pbxproj
+++ b/Set.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		D4EAE2531A88592F00931323 /* Hashing.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAE2521A88592F00931323 /* Hashing.swift */; };
 		D4EAE2551A885A6F00931323 /* Printing.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAE2541A885A6F00931323 /* Printing.swift */; };
 		D4EAE2571A88604A00931323 /* MultisetAlgebraTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAE2561A88604A00931323 /* MultisetAlgebraTests.swift */; };
+		D4EAE2591A8867E200931323 /* MultisetInclusionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAE2581A8867E200931323 /* MultisetInclusionTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -55,6 +56,7 @@
 		D4EAE2521A88592F00931323 /* Hashing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Hashing.swift; sourceTree = "<group>"; };
 		D4EAE2541A885A6F00931323 /* Printing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Printing.swift; sourceTree = "<group>"; };
 		D4EAE2561A88604A00931323 /* MultisetAlgebraTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultisetAlgebraTests.swift; sourceTree = "<group>"; };
+		D4EAE2581A8867E200931323 /* MultisetInclusionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultisetInclusionTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -128,6 +130,7 @@
 				D4EAE2561A88604A00931323 /* MultisetAlgebraTests.swift */,
 				D4EAE2501A88441000931323 /* MultisetCollectionTests.swift */,
 				D4EAE24E1A8841BE00931323 /* MultisetCountTests.swift */,
+				D4EAE2581A8867E200931323 /* MultisetInclusionTests.swift */,
 				D4EAE24C1A883EDD00931323 /* MultisetSequenceTests.swift */,
 				D439CFB619575721005BD842 /* Supporting Files */,
 			);
@@ -267,6 +270,7 @@
 				D439CFB919575721005BD842 /* SetOperationTests.swift in Sources */,
 				D4EAE24F1A8841BE00931323 /* MultisetCountTests.swift in Sources */,
 				D4EAE24D1A883EDD00931323 /* MultisetSequenceTests.swift in Sources */,
+				D4EAE2591A8867E200931323 /* MultisetInclusionTests.swift in Sources */,
 				4ACE19971A3F7C1400A42022 /* SetInclusionTests.swift in Sources */,
 				D4EAE2571A88604A00931323 /* MultisetAlgebraTests.swift in Sources */,
 				D4EAE2511A88441000931323 /* MultisetCollectionTests.swift in Sources */,

--- a/Set.xcodeproj/project.pbxproj
+++ b/Set.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		D439CFB919575721005BD842 /* SetOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D439CFB819575721005BD842 /* SetOperationTests.swift */; };
 		D439CFC31957572E005BD842 /* Set.swift in Sources */ = {isa = PBXBuildFile; fileRef = D439CFC21957572E005BD842 /* Set.swift */; };
 		D4EAE24B1A8835C100931323 /* Multiset.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAE24A1A8835C100931323 /* Multiset.swift */; };
+		D4EAE24D1A883EDD00931323 /* MultisetSequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAE24C1A883EDD00931323 /* MultisetSequenceTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -43,6 +44,7 @@
 		D439CFB819575721005BD842 /* SetOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetOperationTests.swift; sourceTree = "<group>"; };
 		D439CFC21957572E005BD842 /* Set.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Set.swift; sourceTree = "<group>"; };
 		D4EAE24A1A8835C100931323 /* Multiset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Multiset.swift; sourceTree = "<group>"; };
+		D4EAE24C1A883EDD00931323 /* MultisetSequenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultisetSequenceTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -111,6 +113,7 @@
 				4AF6FA881A3EBBD500DDC8EE /* SetInitializerTests.swift */,
 				D439CFB819575721005BD842 /* SetOperationTests.swift */,
 				95B1A51E1A529DF700A7CEE4 /* SetPrintableTests.swift */,
+				D4EAE24C1A883EDD00931323 /* MultisetSequenceTests.swift */,
 				D439CFB619575721005BD842 /* Supporting Files */,
 			);
 			path = SetTests;
@@ -245,6 +248,7 @@
 				4ACE19991A3F7CA600A42022 /* SetHigherOrderFunctionTests.swift in Sources */,
 				95B1A51F1A529DF700A7CEE4 /* SetPrintableTests.swift in Sources */,
 				D439CFB919575721005BD842 /* SetOperationTests.swift in Sources */,
+				D4EAE24D1A883EDD00931323 /* MultisetSequenceTests.swift in Sources */,
 				4ACE19971A3F7C1400A42022 /* SetInclusionTests.swift in Sources */,
 				4AF6FA891A3EBBD500DDC8EE /* SetInitializerTests.swift in Sources */,
 			);

--- a/Set.xcodeproj/project.pbxproj
+++ b/Set.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		D4EAE24B1A8835C100931323 /* Multiset.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAE24A1A8835C100931323 /* Multiset.swift */; };
 		D4EAE24D1A883EDD00931323 /* MultisetSequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAE24C1A883EDD00931323 /* MultisetSequenceTests.swift */; };
 		D4EAE24F1A8841BE00931323 /* MultisetCountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAE24E1A8841BE00931323 /* MultisetCountTests.swift */; };
+		D4EAE2511A88441000931323 /* MultisetCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAE2501A88441000931323 /* MultisetCollectionTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -47,6 +48,7 @@
 		D4EAE24A1A8835C100931323 /* Multiset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Multiset.swift; sourceTree = "<group>"; };
 		D4EAE24C1A883EDD00931323 /* MultisetSequenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultisetSequenceTests.swift; sourceTree = "<group>"; };
 		D4EAE24E1A8841BE00931323 /* MultisetCountTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultisetCountTests.swift; sourceTree = "<group>"; };
+		D4EAE2501A88441000931323 /* MultisetCollectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultisetCollectionTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -115,6 +117,7 @@
 				4AF6FA881A3EBBD500DDC8EE /* SetInitializerTests.swift */,
 				D439CFB819575721005BD842 /* SetOperationTests.swift */,
 				95B1A51E1A529DF700A7CEE4 /* SetPrintableTests.swift */,
+				D4EAE2501A88441000931323 /* MultisetCollectionTests.swift */,
 				D4EAE24E1A8841BE00931323 /* MultisetCountTests.swift */,
 				D4EAE24C1A883EDD00931323 /* MultisetSequenceTests.swift */,
 				D439CFB619575721005BD842 /* Supporting Files */,
@@ -254,6 +257,7 @@
 				D4EAE24F1A8841BE00931323 /* MultisetCountTests.swift in Sources */,
 				D4EAE24D1A883EDD00931323 /* MultisetSequenceTests.swift in Sources */,
 				4ACE19971A3F7C1400A42022 /* SetInclusionTests.swift in Sources */,
+				D4EAE2511A88441000931323 /* MultisetCollectionTests.swift in Sources */,
 				4AF6FA891A3EBBD500DDC8EE /* SetInitializerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Set.xcodeproj/project.pbxproj
+++ b/Set.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		D4EAE24F1A8841BE00931323 /* MultisetCountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAE24E1A8841BE00931323 /* MultisetCountTests.swift */; };
 		D4EAE2511A88441000931323 /* MultisetCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAE2501A88441000931323 /* MultisetCollectionTests.swift */; };
 		D4EAE2531A88592F00931323 /* Hashing.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAE2521A88592F00931323 /* Hashing.swift */; };
+		D4EAE2551A885A6F00931323 /* Printing.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAE2541A885A6F00931323 /* Printing.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -51,6 +52,7 @@
 		D4EAE24E1A8841BE00931323 /* MultisetCountTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultisetCountTests.swift; sourceTree = "<group>"; };
 		D4EAE2501A88441000931323 /* MultisetCollectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultisetCollectionTests.swift; sourceTree = "<group>"; };
 		D4EAE2521A88592F00931323 /* Hashing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Hashing.swift; sourceTree = "<group>"; };
+		D4EAE2541A885A6F00931323 /* Printing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Printing.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -99,6 +101,7 @@
 				D4EAE24A1A8835C100931323 /* Multiset.swift */,
 				D40D2667195F0C1100BC535B /* Unit.swift */,
 				D4EAE2521A88592F00931323 /* Hashing.swift */,
+				D4EAE2541A885A6F00931323 /* Printing.swift */,
 				D439CFA919575720005BD842 /* Supporting Files */,
 			);
 			path = Set;
@@ -248,6 +251,7 @@
 				D439CFC31957572E005BD842 /* Set.swift in Sources */,
 				D4EAE2531A88592F00931323 /* Hashing.swift in Sources */,
 				D40D2668195F0C1100BC535B /* Unit.swift in Sources */,
+				D4EAE2551A885A6F00931323 /* Printing.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Set.xcodeproj/project.pbxproj
+++ b/Set.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		D439CFC31957572E005BD842 /* Set.swift in Sources */ = {isa = PBXBuildFile; fileRef = D439CFC21957572E005BD842 /* Set.swift */; };
 		D4EAE24B1A8835C100931323 /* Multiset.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAE24A1A8835C100931323 /* Multiset.swift */; };
 		D4EAE24D1A883EDD00931323 /* MultisetSequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAE24C1A883EDD00931323 /* MultisetSequenceTests.swift */; };
+		D4EAE24F1A8841BE00931323 /* MultisetCountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAE24E1A8841BE00931323 /* MultisetCountTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -45,6 +46,7 @@
 		D439CFC21957572E005BD842 /* Set.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Set.swift; sourceTree = "<group>"; };
 		D4EAE24A1A8835C100931323 /* Multiset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Multiset.swift; sourceTree = "<group>"; };
 		D4EAE24C1A883EDD00931323 /* MultisetSequenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultisetSequenceTests.swift; sourceTree = "<group>"; };
+		D4EAE24E1A8841BE00931323 /* MultisetCountTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultisetCountTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -113,6 +115,7 @@
 				4AF6FA881A3EBBD500DDC8EE /* SetInitializerTests.swift */,
 				D439CFB819575721005BD842 /* SetOperationTests.swift */,
 				95B1A51E1A529DF700A7CEE4 /* SetPrintableTests.swift */,
+				D4EAE24E1A8841BE00931323 /* MultisetCountTests.swift */,
 				D4EAE24C1A883EDD00931323 /* MultisetSequenceTests.swift */,
 				D439CFB619575721005BD842 /* Supporting Files */,
 			);
@@ -248,6 +251,7 @@
 				4ACE19991A3F7CA600A42022 /* SetHigherOrderFunctionTests.swift in Sources */,
 				95B1A51F1A529DF700A7CEE4 /* SetPrintableTests.swift in Sources */,
 				D439CFB919575721005BD842 /* SetOperationTests.swift in Sources */,
+				D4EAE24F1A8841BE00931323 /* MultisetCountTests.swift in Sources */,
 				D4EAE24D1A883EDD00931323 /* MultisetSequenceTests.swift in Sources */,
 				4ACE19971A3F7C1400A42022 /* SetInclusionTests.swift in Sources */,
 				4AF6FA891A3EBBD500DDC8EE /* SetInitializerTests.swift in Sources */,

--- a/Set.xcodeproj/project.pbxproj
+++ b/Set.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		D4EAE24D1A883EDD00931323 /* MultisetSequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAE24C1A883EDD00931323 /* MultisetSequenceTests.swift */; };
 		D4EAE24F1A8841BE00931323 /* MultisetCountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAE24E1A8841BE00931323 /* MultisetCountTests.swift */; };
 		D4EAE2511A88441000931323 /* MultisetCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAE2501A88441000931323 /* MultisetCollectionTests.swift */; };
+		D4EAE2531A88592F00931323 /* Hashing.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAE2521A88592F00931323 /* Hashing.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,6 +50,7 @@
 		D4EAE24C1A883EDD00931323 /* MultisetSequenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultisetSequenceTests.swift; sourceTree = "<group>"; };
 		D4EAE24E1A8841BE00931323 /* MultisetCountTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultisetCountTests.swift; sourceTree = "<group>"; };
 		D4EAE2501A88441000931323 /* MultisetCollectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultisetCollectionTests.swift; sourceTree = "<group>"; };
+		D4EAE2521A88592F00931323 /* Hashing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Hashing.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -96,6 +98,7 @@
 				D439CFC21957572E005BD842 /* Set.swift */,
 				D4EAE24A1A8835C100931323 /* Multiset.swift */,
 				D40D2667195F0C1100BC535B /* Unit.swift */,
+				D4EAE2521A88592F00931323 /* Hashing.swift */,
 				D439CFA919575720005BD842 /* Supporting Files */,
 			);
 			path = Set;
@@ -243,6 +246,7 @@
 			files = (
 				D4EAE24B1A8835C100931323 /* Multiset.swift in Sources */,
 				D439CFC31957572E005BD842 /* Set.swift in Sources */,
+				D4EAE2531A88592F00931323 /* Hashing.swift in Sources */,
 				D40D2668195F0C1100BC535B /* Unit.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Set.xcodeproj/project.pbxproj
+++ b/Set.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		D4EAE2511A88441000931323 /* MultisetCollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAE2501A88441000931323 /* MultisetCollectionTests.swift */; };
 		D4EAE2531A88592F00931323 /* Hashing.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAE2521A88592F00931323 /* Hashing.swift */; };
 		D4EAE2551A885A6F00931323 /* Printing.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAE2541A885A6F00931323 /* Printing.swift */; };
+		D4EAE2571A88604A00931323 /* MultisetAlgebraTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EAE2561A88604A00931323 /* MultisetAlgebraTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,6 +54,7 @@
 		D4EAE2501A88441000931323 /* MultisetCollectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultisetCollectionTests.swift; sourceTree = "<group>"; };
 		D4EAE2521A88592F00931323 /* Hashing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Hashing.swift; sourceTree = "<group>"; };
 		D4EAE2541A885A6F00931323 /* Printing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Printing.swift; sourceTree = "<group>"; };
+		D4EAE2561A88604A00931323 /* MultisetAlgebraTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultisetAlgebraTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -123,6 +125,7 @@
 				4AF6FA881A3EBBD500DDC8EE /* SetInitializerTests.swift */,
 				D439CFB819575721005BD842 /* SetOperationTests.swift */,
 				95B1A51E1A529DF700A7CEE4 /* SetPrintableTests.swift */,
+				D4EAE2561A88604A00931323 /* MultisetAlgebraTests.swift */,
 				D4EAE2501A88441000931323 /* MultisetCollectionTests.swift */,
 				D4EAE24E1A8841BE00931323 /* MultisetCountTests.swift */,
 				D4EAE24C1A883EDD00931323 /* MultisetSequenceTests.swift */,
@@ -265,6 +268,7 @@
 				D4EAE24F1A8841BE00931323 /* MultisetCountTests.swift in Sources */,
 				D4EAE24D1A883EDD00931323 /* MultisetSequenceTests.swift in Sources */,
 				4ACE19971A3F7C1400A42022 /* SetInclusionTests.swift in Sources */,
+				D4EAE2571A88604A00931323 /* MultisetAlgebraTests.swift in Sources */,
 				D4EAE2511A88441000931323 /* MultisetCollectionTests.swift in Sources */,
 				4AF6FA891A3EBBD500DDC8EE /* SetInitializerTests.swift in Sources */,
 			);

--- a/Set/Hashing.swift
+++ b/Set/Hashing.swift
@@ -1,0 +1,15 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+/// Hashes a sequence of `Hashable` elements.
+internal func hashValues<S: SequenceType where S.Generator.Element: Hashable>(sequence: S) -> Int {
+	var h = reduce(sequence, 0) { into, each in
+		var h = into + each.hashValue
+		h += (h << 10)
+		h ^= (h >> 6)
+		return h
+	}
+	h += (h << 3)
+	h ^= (h >> 11)
+	h += (h << 15)
+	return h
+}

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 /// A multiset of elements and their counts.
-public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollectionType {
+public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollectionType, Equatable {
 	// MARK: Constructors
 
 	/// Constructs a `Set` with the elements of `sequence`.
@@ -159,6 +159,13 @@ public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCo
 
 	/// Counts indexed by value.
 	private var values: [Element: Int]
+}
+
+
+// MARK: Equatable
+
+public func == <Element> (a: Multiset<Element>, b: Multiset<Element>) -> Bool {
+	return a.values == b.values
 }
 
 

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -10,6 +10,11 @@ public struct Multiset<Element: Hashable>: ExtensibleCollectionType {
 		extend(sequence)
 	}
 
+	/// Constructs a `Set` from a variadic parameter list.
+	public init(_ elements: Element...) {
+		self.init(elements)
+	}
+
 	/// Constructs the empty `Multiset`.
 	public init() {
 		self.init(values: [:])

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -102,7 +102,9 @@ public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCo
 	///
 	/// This is a new set with all elements from the receiver which are not contained in `set`.
 	public func complement(set: Multiset) -> Multiset {
-		return filter { !set.contains($0) }
+		return Multiset(values: countDistinct <= set.countDistinct ?
+			Swift.map(values) { ($0, $1 - set.count($0)) }
+		:	Swift.map(set.values) { ($0, $1 - self.count($0)) })
 	}
 
 	/// Returns the symmetric difference of `self` and `set`.

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -267,7 +267,7 @@ public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCo
 	private init<S: SequenceType where S.Generator.Element == Dictionary<Element, Int>.Element>(values: S) {
 		self.values = [:]
 		for (element, count) in SequenceOf<(Element, Int)>(values) {
-			self.values[element] = count
+			if count > 0 { self.values[element] = count }
 		}
 	}
 

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -87,6 +87,14 @@ public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCo
 	}
 
 
+	// MARK: Higher-order functions
+
+	/// Returns a new set including only those elements `x` where `includeElement(x)` is true.
+	public func filter(includeElement: Element -> Bool) -> Multiset {
+		return Multiset(lazy(self).filter(includeElement))
+	}
+
+
 	// MARK: ArrayLiteralConvertible
 
 	public init(arrayLiteral elements: Element...) {

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 /// A multiset of elements and their counts.
-public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollectionType, Equatable {
+public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollectionType, Hashable {
 	// MARK: Constructors
 
 	/// Constructs a `Set` with the elements of `sequence`.
@@ -148,6 +148,17 @@ public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCo
 		insert(element)
 	}
 
+
+	// MARK: Hashable
+
+	/// Hashes using Bob Jenkins’ one-at-a-time hash.
+	///
+	/// http://en.wikipedia.org/wiki/Jenkins_hash_function#one-at-a-time
+	///
+	/// NB: Jenkins’ usage appears to have been string keys; the usage employed here seems similar but may have subtle differences which have yet to be discovered.
+	public var hashValue: Int {
+		return hashValues(self)
+	}
 
 
 	// MARK: Private

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -85,15 +85,17 @@ public struct Multiset<Element: Hashable>: SequenceType, CollectionType {
 
 	// MARK: CollectionType
 
-	public var startIndex: DictionaryIndex<Element, Int> {
+	public typealias Index = DictionaryIndex<Element, Int>
+
+	public var startIndex: Index {
 		return values.startIndex
 	}
 
-	public var endIndex: DictionaryIndex<Element, Int> {
+	public var endIndex: Index {
 		return values.endIndex
 	}
 
-	public subscript(index: DictionaryIndex<Element, Int>) -> Element {
+	public subscript(index: Index) -> Element {
 		return values[index].0
 	}
 

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -4,6 +4,12 @@
 public struct Multiset<Element: Hashable>: ExtensibleCollectionType {
 	// MARK: Constructors
 
+	/// Constructs a `Set` with the elements of `sequence`.
+	public init<S: SequenceType where S.Generator.Element == Element>(_ sequence: S) {
+		self.init(values: [:])
+		extend(sequence)
+	}
+
 	/// Constructs the empty `Multiset`.
 	public init() {
 		self.init(values: [:])

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -93,6 +93,13 @@ public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCo
 		:	set.filter { self.contains($0) }
 	}
 
+	/// Returns the relative complement of `set` in `self`.
+	///
+	/// This is a new set with all elements from the receiver which are not contained in `set`.
+	public func complement(set: Multiset) -> Multiset {
+		return filter { !set.contains($0) }
+	}
+
 
 	// MARK: Higher-order functions
 

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 /// A multiset of elements and their counts.
-public struct Multiset<Element: Hashable>: SequenceType {
+public struct Multiset<Element: Hashable>: SequenceType, CollectionType {
 	// MARK: Constructors
 
 	/// Constructs the empty `Multiset`.
@@ -80,6 +80,21 @@ public struct Multiset<Element: Hashable>: SequenceType {
 			--current.count
 			return current.element
 		}
+	}
+
+
+	// MARK: CollectionType
+
+	public var startIndex: DictionaryIndex<Element, Int> {
+		return values.startIndex
+	}
+
+	public var endIndex: DictionaryIndex<Element, Int> {
+		return values.endIndex
+	}
+
+	public subscript(index: DictionaryIndex<Element, Int>) -> Element {
+		return values[index].0
 	}
 
 

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -48,7 +48,7 @@ public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCo
 
 	/// True iff `element` is in the receiver, as defined by its hash and equality.
 	public func contains(element: Element) -> Bool {
-		return count(element) == 0
+		return count(element) > 0
 	}
 
 	/// Returns the number of occurrences of `element` in the receiver.

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 /// A multiset of elements and their counts.
-public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollectionType, Hashable {
+public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollectionType, Hashable, Printable, DebugPrintable {
 	// MARK: Constructors
 
 	/// Constructs a `Set` with the elements of `sequence`.
@@ -158,6 +158,20 @@ public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCo
 	/// NB: Jenkins’ usage appears to have been string keys; the usage employed here seems similar but may have subtle differences which have yet to be discovered.
 	public var hashValue: Int {
 		return hashValues(self)
+	}
+
+
+	// MARK: Printable
+
+	public var description: String {
+		return describe(self)
+	}
+
+
+	// MARK: DebugPrintable
+
+	public var debugDescription: String {
+		return debugDescribe(self)
 	}
 
 

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -86,6 +86,13 @@ public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCo
 		return self + set
 	}
 
+	/// Returns the intersection of the receiver and `set`.
+	public func intersection(set: Multiset) -> Multiset {
+		return count <= set.count ?
+			filter { set.contains($0) }
+		:	set.filter { self.contains($0) }
+	}
+
 
 	// MARK: Higher-order functions
 

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -95,6 +95,11 @@ public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCo
 	}
 
 
+	/// Applies `transform` to each element and returns a new set which is the union of each resulting set.
+	public func flatMap<Result, S: SequenceType where S.Generator.Element == Result>(transform: Element -> S) -> Multiset<Result> {
+		return reduce([]) { $0 + transform($1) }
+	}
+
 	/// Combines each element of the receiver with an accumulator value using `combine`, starting with `initial`.
 	public func reduce<Into>(initial: Into, combine: (Into, Element) -> Into) -> Into {
 		return Swift.reduce(self, initial, combine)

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -30,7 +30,7 @@ public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCo
 
 	/// The number of entries in the receiver.
 	public var count: Int {
-		return reduce(lazy(values).map { $0.1 }, 0, +)
+		return Swift.reduce(lazy(values).map { $0.1 }, 0, +)
 	}
 
 	/// The number of distinct entries in the receiver.
@@ -92,6 +92,12 @@ public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCo
 	/// Returns a new set including only those elements `x` where `includeElement(x)` is true.
 	public func filter(includeElement: Element -> Bool) -> Multiset {
 		return Multiset(lazy(self).filter(includeElement))
+	}
+
+
+	/// Combines each element of the receiver with an accumulator value using `combine`, starting with `initial`.
+	public func reduce<Into>(initial: Into, combine: (Into, Element) -> Into) -> Into {
+		return Swift.reduce(self, initial, combine)
 	}
 
 

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -51,6 +51,11 @@ public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCo
 		return values[element] != nil
 	}
 
+	/// Returns the number of occurrences of `element` in the receiver.
+	public func count(element: Element) -> Int {
+		return values[element] ?? 0
+	}
+
 	/// Retrieve an arbitrary element & insert with empty subscript.
 	public subscript(v: ()) -> Element {
 		get { return values[values.startIndex].0 }

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -263,6 +263,14 @@ public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCo
 		self.values = values
 	}
 
+	/// Constructs a `Multiset` with a sequence of element/count pairs.
+	private init<S: SequenceType where S.Generator.Element == Dictionary<Element, Int>.Element>(values: S) {
+		self.values = [:]
+		for (element, count) in SequenceOf<(Element, Int)>(values) {
+			self.values[element] = count
+		}
+	}
+
 	/// Counts indexed by value.
 	private var values: [Element: Int]
 }

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 /// A multiset of elements and their counts.
-public struct Multiset<Element: Hashable>: SequenceType, CollectionType {
+public struct Multiset<Element: Hashable>: ExtensibleCollectionType {
 	// MARK: Constructors
 
 	/// Constructs the empty `Multiset`.
@@ -105,6 +105,26 @@ public struct Multiset<Element: Hashable>: SequenceType, CollectionType {
 			return element
 		}
 	}
+
+
+	// MARK: ExtensibleCollectionType
+
+	/// In theory, reserve capacity for `n` elements. However, `Dictionary` does not implement `reserveCapacity`, so we just silently ignore it.
+	public func reserveCapacity(n: Multiset.Index.Distance) {}
+
+	/// Inserts each element of `sequence` into the receiver.
+	public mutating func extend<S: SequenceType where S.Generator.Element == Element>(sequence: S) {
+		// Note that this should just be for each in sequence; this is working around a compiler bug.
+		for each in SequenceOf<Element>(sequence) {
+			insert(each)
+		}
+	}
+
+	/// Appends `element` onto the `Set`.
+	public mutating func append(element: Element) {
+		insert(element)
+	}
+
 
 
 	// MARK: Private

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -85,18 +85,25 @@ public struct Multiset<Element: Hashable>: SequenceType, CollectionType {
 
 	// MARK: CollectionType
 
-	public typealias Index = DictionaryIndex<Element, Int>
+	public typealias Index = MultisetIndex<Element>
 
 	public var startIndex: Index {
-		return values.startIndex
+		return MultisetIndex(from: values.startIndex, delta: 0, max: count)
 	}
 
 	public var endIndex: Index {
-		return values.endIndex
+		return MultisetIndex(from: values.endIndex, delta: 0, max: count)
 	}
 
 	public subscript(index: Index) -> Element {
-		return values[index].0
+		let (element, count) = values[index.from]
+		if index.delta > (count - 1) {
+			return self[MultisetIndex(from: index.from.successor(), delta: index.delta - count, max: self.count)]
+		} else if index.delta < -(count - 1) {
+			return self[MultisetIndex(from: index.from.predecessor(), delta: index.delta + count, max: self.count)]
+		} else {
+			return element
+		}
 	}
 
 

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -28,7 +28,7 @@ public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCo
 
 	// MARK: Properties
 
-	/// The number of entries in the multiset.
+	/// The number of entries in the receiver.
 	public var count: Int {
 		return reduce(lazy(values).map { $0.1 }, 0, +)
 	}

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -225,8 +225,16 @@ public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCo
 }
 
 
-// MARK: Equatable
+// MARK: - Operators
 
+/// Extends a `set` with the elements of a `sequence`.
+public func += <S: SequenceType> (inout set: Multiset<S.Generator.Element>, sequence: S) {
+	set.extend(sequence)
+}
+
+
+
+// Defines equality for multisets.
 public func == <Element> (a: Multiset<Element>, b: Multiset<Element>) -> Bool {
 	return a.values == b.values
 }

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -33,6 +33,11 @@ public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCo
 		return reduce(lazy(values).map { $0.1 }, 0, +)
 	}
 
+	/// The number of distinct entries in the receiver.
+	public var countDistinct: Int {
+		return values.count
+	}
+
 	/// True iff `count` is 0.
 	public var isEmpty: Bool {
 		return values.isEmpty

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -35,6 +35,12 @@ public struct Multiset<Element: Hashable>: SequenceType {
 		return values[element] != nil
 	}
 
+	/// Retrieve an arbitrary element & insert with empty subscript.
+	public subscript(v: ()) -> Element {
+		get { return values[values.startIndex].0 }
+		set { insert(newValue) }
+	}
+
 	/// Inserts `element` into the receiver.
 	public mutating func insert(element: Element) {
 		values[element] = (values[element] ?? 0) + 1

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -251,6 +251,16 @@ public func -= <Element> (inout set: Multiset<Element>, other: Multiset<Element>
 }
 
 
+/// Intersects with `set` with `other`.
+public func &= <Element> (inout set: Multiset<Element>, other: Multiset<Element>) {
+	set = set.intersection(other)
+}
+
+/// Returns the intersection of `set` and `other`.
+public func & <Element> (set: Multiset<Element>, other: Multiset<Element>) -> Multiset<Element> {
+	return set.intersection(other)
+}
+
 
 // Defines equality for multisets.
 public func == <Element> (a: Multiset<Element>, b: Multiset<Element>) -> Bool {

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -48,7 +48,7 @@ public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCo
 
 	/// True iff `element` is in the receiver, as defined by its hash and equality.
 	public func contains(element: Element) -> Bool {
-		return values[element] != nil
+		return count(element) == 0
 	}
 
 	/// Returns the number of occurrences of `element` in the receiver.

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -51,6 +51,11 @@ public struct Multiset<Element: Hashable> {
 		}
 	}
 
+	/// Removes all elements from the reeiver.
+	public mutating func removeAll() {
+		values = [:]
+	}
+
 
 	// MARK: Private
 

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 /// A multiset of elements and their counts.
-public struct Multiset<Element: Hashable> {
+public struct Multiset<Element: Hashable>: SequenceType {
 	// MARK: Constructors
 
 	/// Constructs the empty `Multiset`.
@@ -54,6 +54,26 @@ public struct Multiset<Element: Hashable> {
 	/// Removes all elements from the reeiver.
 	public mutating func removeAll() {
 		values = [:]
+	}
+
+
+	// MARK: SequenceType
+
+	public func generate() -> GeneratorOf<Element> {
+		var generator = values.generate()
+		let next = { generator.next() }
+		var current: (element: Element?, count: Int) = (nil, 0)
+		return GeneratorOf {
+			while current.count <= 0 {
+				if let (element, count) = next() {
+					current = (element, count)
+					break
+				}
+				else { return nil }
+			}
+			--current.count
+			return current.element
+		}
 	}
 
 

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -93,9 +93,9 @@ public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCo
 
 	/// Returns the intersection of the receiver and `set`.
 	public func intersection(set: Multiset) -> Multiset {
-		return count <= set.count ?
-			filter { set.contains($0) }
-		:	set.filter { self.contains($0) }
+		return Multiset(values: countDistinct <= set.countDistinct ?
+			Swift.map(values) { ($0, min($1, set.count($0))) }
+		:	Swift.map(set.values) { ($0, min($1, self.count($0))) })
 	}
 
 	/// Returns the relative complement of `set` in `self`.

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -109,7 +109,7 @@ public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCo
 	///
 	/// This is a new set with all elements that exist only in `self` or `set`, and not both.
 	public func difference(set: Multiset) -> Multiset {
-		return union(set) - intersection(set)
+		return (set - self) + (self - set)
 	}
 
 

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -200,6 +200,7 @@ public func == <Element: Hashable> (left: MultisetIndex<Element>, right: Multise
 	}
 }
 
+
 // MARK: Comparable
 
 public func < <Element: Hashable> (left: MultisetIndex<Element>, right: MultisetIndex<Element>) -> Bool {

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -100,6 +100,14 @@ public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCo
 		return filter { !set.contains($0) }
 	}
 
+	/// Returns the symmetric difference of `self` and `set`.
+	///
+	/// This is a new set with all elements that exist only in `self` or `set`, and not both.
+	public func difference(set: Multiset) -> Multiset {
+		return union(set) - intersection(set)
+	}
+
+
 
 	// MARK: Higher-order functions
 

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -79,6 +79,14 @@ public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCo
 	}
 
 
+	// MARK: Algebraic operations
+
+	/// Returns the union of the receiver and `set`.
+	public func union(set: Multiset) -> Multiset {
+		return self + set
+	}
+
+
 	// MARK: ArrayLiteralConvertible
 
 	public init(arrayLiteral elements: Element...) {

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 /// A multiset of elements and their counts.
-public struct Multiset<Element: Hashable>: ExtensibleCollectionType {
+public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollectionType {
 	// MARK: Constructors
 
 	/// Constructs a `Set` with the elements of `sequence`.
@@ -71,6 +71,13 @@ public struct Multiset<Element: Hashable>: ExtensibleCollectionType {
 	/// Removes all elements from the reeiver.
 	public mutating func removeAll() {
 		values = [:]
+	}
+
+
+	// MARK: ArrayLiteralConvertible
+
+	public init(arrayLiteral elements: Element...) {
+		self.init(elements)
 	}
 
 

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -102,9 +102,7 @@ public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCo
 	///
 	/// This is a new set with all elements from the receiver which are not contained in `set`.
 	public func complement(set: Multiset) -> Multiset {
-		return Multiset(values: countDistinct <= set.countDistinct ?
-			Swift.map(values) { ($0, $1 - set.count($0)) }
-		:	Swift.map(set.values) { ($0, $1 - self.count($0)) })
+		return Multiset(values: Swift.map(values) { ($0, $1 - set.count($0)) })
 	}
 
 	/// Returns the symmetric difference of `self` and `set`.

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -94,6 +94,10 @@ public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCo
 		return Multiset(lazy(self).filter(includeElement))
 	}
 
+	/// Returns a new set with the result of applying `transform` to each element.
+	public func map<Result>(transform: Element -> Result) -> Multiset<Result> {
+		return flatMap { [transform($0)] }
+	}
 
 	/// Applies `transform` to each element and returns a new set which is the union of each resulting set.
 	public func flatMap<Result, S: SequenceType where S.Generator.Element == Result>(transform: Element -> S) -> Multiset<Result> {

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -240,6 +240,17 @@ public func += <S: SequenceType> (inout set: Multiset<S.Generator.Element>, sequ
 }
 
 
+/// Returns a new set with all elements from `set` which are not contained in `other`.
+public func - <Element> (set: Multiset<Element>, other: Multiset<Element>) -> Multiset<Element> {
+	return set.complement(other)
+}
+
+/// Removes all elements in `other` from `set`.
+public func -= <Element> (inout set: Multiset<Element>, other: Multiset<Element>) {
+	set = set.complement(other)
+}
+
+
 
 // Defines equality for multisets.
 public func == <Element> (a: Multiset<Element>, b: Multiset<Element>) -> Bool {

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -108,6 +108,29 @@ public struct Multiset<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCo
 	}
 
 
+	// MARK: Set inclusion functions
+
+	/// True iff the receiver is a subset of (is included in) `set`.
+	public func subset(set: Multiset) -> Bool {
+		return complement(set) == Multiset()
+	}
+
+	/// True iff the receiver is a subset of but not equal to `set`.
+	public func strictSubset(set: Multiset) -> Bool {
+		return subset(set) && self != set
+	}
+
+	/// True iff the receiver is a superset of (includes) `set`.
+	public func superset(set: Multiset) -> Bool {
+		return set.subset(self)
+	}
+
+	/// True iff the receiver is a superset of but not equal to `set`.
+	public func strictSuperset(set: Multiset) -> Bool {
+		return set.strictSubset(self)
+	}
+
+
 
 	// MARK: Higher-order functions
 

--- a/Set/Multiset.swift
+++ b/Set/Multiset.swift
@@ -110,3 +110,46 @@ public struct Multiset<Element: Hashable>: SequenceType, CollectionType {
 	/// Counts indexed by value.
 	private var values: [Element: Int]
 }
+
+
+/// The index for values of a multiset.
+public struct MultisetIndex<Element: Hashable>: BidirectionalIndexType, Comparable {
+	// MARK: BidirectionalIndexType
+
+	public func predecessor() -> MultisetIndex {
+		return MultisetIndex(from: from, delta: delta - 1, max: max)
+	}
+
+	public func successor() -> MultisetIndex {
+		return MultisetIndex(from: from, delta: delta + 1, max: max)
+	}
+
+
+	// MARK: Private
+
+	private let from: DictionaryIndex<Element, Int>
+	private let delta: Int
+	private let max: Int
+}
+
+
+// MARK: Equatable
+
+public func == <Element: Hashable> (left: MultisetIndex<Element>, right: MultisetIndex<Element>) -> Bool {
+	if left.from == right.from {
+		return left.delta == right.delta && left.max == right.max
+	} else {
+		return left.max == right.max && abs(left.delta - right.delta) == left.max
+	}
+}
+
+// MARK: Comparable
+
+public func < <Element: Hashable> (left: MultisetIndex<Element>, right: MultisetIndex<Element>) -> Bool {
+	if left.from == right.from {
+		return left.delta < right.delta
+	} else if left.from < right.from {
+		return (left.delta - right.delta) < left.max
+	}
+	return false
+}

--- a/Set/Printing.swift
+++ b/Set/Printing.swift
@@ -1,0 +1,17 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+/// Describes a sequence as a set.
+internal func describe<S: SequenceType>(sequence: S) -> String {
+	let description = join(", ", lazy(sequence).map(toString))
+	return description.isEmpty ?
+		"{}"
+	:	"{ \(description) }"
+}
+
+/// Debug-describes a sequence as a set.
+internal func debugDescribe<S: SequenceType>(sequence: S) -> String {
+	let description = join(", ", lazy(sequence).map(toDebugString))
+	return description.isEmpty ?
+		"{}"
+	:	"{ \(description) }"
+}

--- a/Set/Printing.swift
+++ b/Set/Printing.swift
@@ -15,5 +15,5 @@ internal func debugDescribe<S: SequenceType>(sequence: S) -> String {
 private func wrapDescription(description: String) -> String {
 	return description.isEmpty ?
 		"{}"
-	:	"{ \(description) }"
+	:	"{\(description)}"
 }

--- a/Set/Printing.swift
+++ b/Set/Printing.swift
@@ -2,15 +2,17 @@
 
 /// Describes a sequence as a set.
 internal func describe<S: SequenceType>(sequence: S) -> String {
-	let description = join(", ", lazy(sequence).map(toString))
-	return description.isEmpty ?
-		"{}"
-	:	"{ \(description) }"
+	return wrapDescription(join(", ", lazy(sequence).map(toString)))
 }
 
 /// Debug-describes a sequence as a set.
 internal func debugDescribe<S: SequenceType>(sequence: S) -> String {
-	let description = join(", ", lazy(sequence).map(toDebugString))
+	return wrapDescription(join(", ", lazy(sequence).map(toDebugString)))
+}
+
+
+/// Wraps a string appropriately for formatting as a set.
+private func wrapDescription(description: String) -> String {
 	return description.isEmpty ?
 		"{}"
 	:	"{ \(description) }"

--- a/Set/Printing.swift
+++ b/Set/Printing.swift
@@ -2,14 +2,19 @@
 
 /// Describes a sequence as a set.
 internal func describe<S: SequenceType>(sequence: S) -> String {
-	return wrapDescription(join(", ", lazy(sequence).map(toString)))
+	return mapDescription(sequence, toString)
 }
 
 /// Debug-describes a sequence as a set.
 internal func debugDescribe<S: SequenceType>(sequence: S) -> String {
-	return wrapDescription(join(", ", lazy(sequence).map(toDebugString)))
+	return mapDescription(sequence, toDebugString)
 }
 
+
+/// Maps the elements of `sequence` with `transform` and formats them as a set.
+private func mapDescription<S: SequenceType>(sequence: S, transform: S.Generator.Element -> String) -> String {
+	return wrapDescription(join(", ", lazy(sequence).map(transform)))
+}
 
 /// Wraps a string appropriately for formatting as a set.
 private func wrapDescription(description: String) -> String {

--- a/Set/Set.swift
+++ b/Set/Set.swift
@@ -158,15 +158,17 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 
 	// MARK: CollectionType
 
-	public var startIndex: DictionaryIndex<Element, Unit> {
+	public typealias Index = DictionaryIndex<Element, Unit>
+
+	public var startIndex: Index {
 		return values.startIndex
 	}
 
-	public var endIndex: DictionaryIndex<Element, Unit> {
+	public var endIndex: Index {
 		return values.endIndex
 	}
 
-	public subscript(index: DictionaryIndex<Element, Unit>) -> Element {
+	public subscript(index: Index) -> Element {
 		return values[index].0
 	}
 

--- a/Set/Set.swift
+++ b/Set/Set.swift
@@ -127,7 +127,7 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 
 	/// Applies `transform` to each element and returns a new set which is the union of each resulting set.
 	public func flatMap<Result, S: SequenceType where S.Generator.Element == Result>(transform: Element -> S) -> Set<Result> {
-		return reduce(Set<Result>()) { $0 + transform($1) }
+		return reduce([]) { $0 + transform($1) }
 	}
 
 	/// Combines each element of the receiver with an accumulator value using `combine`, starting with `initial`.

--- a/Set/Set.swift
+++ b/Set/Set.swift
@@ -181,9 +181,7 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 	/// Inserts each element of `sequence` into the receiver.
 	public mutating func extend<S: SequenceType where S.Generator.Element == Element>(sequence: S) {
 		// Note that this should just be for each in sequence; this is working around a compiler bug.
-		var generator = sequence.generate()
-		let next: () -> Element? = { generator.next() }
-		for each in GeneratorOf(next) {
+		for each in SequenceOf<Element>(sequence) {
 			insert(each)
 		}
 	}

--- a/Set/Set.swift
+++ b/Set/Set.swift
@@ -30,7 +30,9 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 	// MARK: Properties
 
 	/// The number of entries in the set.
-	public var count: Int { return values.count }
+	public var count: Int {
+		return values.count
+	}
 
 	/// True iff `count` is 0.
 	public var isEmpty: Bool {

--- a/Set/Set.swift
+++ b/Set/Set.swift
@@ -175,7 +175,7 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 
 	// MARK: ExtensibleCollectionType
 
-	/// In theory, reserve capacity for `n` elements. However, Dictionary does not implement reserveCapacity(), so we just silently ignore it.
+	/// In theory, reserve capacity for `n` elements. However, `Dictionary` does not implement `reserveCapacity`, so we just silently ignore it.
 	public func reserveCapacity(n: Set.Index.Distance) {}
 
 	/// Inserts each element of `sequence` into the receiver.

--- a/Set/Set.swift
+++ b/Set/Set.swift
@@ -202,16 +202,7 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 	///
 	/// NB: Jenkins’ usage appears to have been string keys; the usage employed here seems similar but may have subtle differences which have yet to be discovered.
 	public var hashValue: Int {
-		var h = reduce(0) { into, each in
-			var h = into + each.hashValue
-			h += (h << 10)
-			h ^= (h >> 6)
-			return h
-		}
-		h += (h << 3)
-		h ^= (h >> 11)
-		h += (h << 15)
-		return h
+		return hashValues(self)
 	}
 
 

--- a/Set/Set.swift
+++ b/Set/Set.swift
@@ -209,18 +209,14 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 	// MARK: Printable
 
 	public var description: String {
-		return count > 0 ?
-			"{" + join(", ", lazy(self).map(toString)) + "}"
-		:	"{}"
+		return describe(self)
 	}
 
 
 	// MARK: DebugPrintable
 	
 	public var debugDescription: String {
-		return count > 0 ?
-			"{" + join(", ", lazy(self).map(toDebugString)) + "}"
-		:	"{}"
+		return debugDescribe(self)
 	}
 	
 

--- a/Set/Set.swift
+++ b/Set/Set.swift
@@ -45,6 +45,12 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 		return values[element] != nil
 	}
 
+	/// Retrieve an arbitrary element & insert with empty subscript.
+	public subscript(v: ()) -> Element {
+		get { return values[values.startIndex].0 }
+		set { insert(newValue) }
+	}
+
 	/// Inserts `element` into the receiver, if it doesn’t already exist.
 	public mutating func insert(element: Element) {
 		values[element] = Unit()
@@ -158,11 +164,6 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 
 	public var endIndex: DictionaryIndex<Element, Unit> {
 		return values.endIndex
-	}
-
-	public subscript(v: ()) -> Element {
-		get { return values[values.startIndex].0 }
-		set { insert(newValue) }
 	}
 
 	public subscript(index: DictionaryIndex<Element, Unit>) -> Element {

--- a/Set/Set.swift
+++ b/Set/Set.swift
@@ -29,7 +29,7 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 
 	// MARK: Properties
 
-	/// The number of entries in the set.
+	/// The number of entries in the receiver.
 	public var count: Int {
 		return values.count
 	}

--- a/Set/Set.swift
+++ b/Set/Set.swift
@@ -152,8 +152,13 @@ public struct Set<Element: Hashable>: ArrayLiteralConvertible, ExtensibleCollect
 
 	// MARK: CollectionType
 
-	public var startIndex: DictionaryIndex<Element, Unit> { return values.startIndex }
-	public var endIndex: DictionaryIndex<Element, Unit> { return values.endIndex }
+	public var startIndex: DictionaryIndex<Element, Unit> {
+		return values.startIndex
+	}
+
+	public var endIndex: DictionaryIndex<Element, Unit> {
+		return values.endIndex
+	}
 
 	public subscript(v: ()) -> Element {
 		get { return values[values.startIndex].0 }

--- a/SetTests/MultisetAlgebraTests.swift
+++ b/SetTests/MultisetAlgebraTests.swift
@@ -11,4 +11,8 @@ final class MultisetAlgebraTests: XCTestCase {
 	func testIntersectionOfMultisetsMinimizesMultiplicities() {
 		XCTAssertEqual((Multiset(1, 1, 1, 2, 3) & Multiset(1, 1, 2, 4)), Multiset(1, 1, 2))
 	}
+
+	func testComplementOfMultisetsSubtractsMultiplicities() {
+		XCTAssertEqual((Multiset(1, 1, 1, 2, 3) - Multiset(1, 1, 2, 4)), Multiset(1, 3))
+	}
 }

--- a/SetTests/MultisetAlgebraTests.swift
+++ b/SetTests/MultisetAlgebraTests.swift
@@ -7,4 +7,8 @@ final class MultisetAlgebraTests: XCTestCase {
 	func testUnionOfMultisetsSumsMultiplicities() {
 		XCTAssertEqual((Multiset(1, 2, 3) + Multiset(1)).count(1), 2)
 	}
+
+	func testIntersectionOfMultisetsMinimizesMultiplicities() {
+		XCTAssertEqual((Multiset(1, 1, 1, 2, 3) & Multiset(1, 1, 2, 4)), Multiset(1, 1, 2))
+	}
 }

--- a/SetTests/MultisetAlgebraTests.swift
+++ b/SetTests/MultisetAlgebraTests.swift
@@ -1,0 +1,10 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+import Set
+import XCTest
+
+final class MultisetAlgebraTests: XCTestCase {
+	func testUnionOfMultisetsSumsMultiplicities() {
+		XCTAssertEqual((Multiset(1, 2, 3) + Multiset(1)).count(1), 2)
+	}
+}

--- a/SetTests/MultisetAlgebraTests.swift
+++ b/SetTests/MultisetAlgebraTests.swift
@@ -16,4 +16,8 @@ final class MultisetAlgebraTests: XCTestCase {
 		XCTAssertEqual((Multiset(1, 1, 1, 2, 3) - Multiset(1, 1, 2, 4, 5)), Multiset(1, 3))
 		XCTAssertEqual((Multiset(1, 1, 2, 4, 5) - Multiset(1, 1, 1, 2, 3)), Multiset(4, 5))
 	}
+
+	func testDifferenceOfMultisets() {
+		XCTAssertEqual(Multiset(1, 1, 1, 2, 3).difference(Multiset(1, 1, 2, 4)), Multiset(1, 3, 4))
+	}
 }

--- a/SetTests/MultisetAlgebraTests.swift
+++ b/SetTests/MultisetAlgebraTests.swift
@@ -13,6 +13,7 @@ final class MultisetAlgebraTests: XCTestCase {
 	}
 
 	func testComplementOfMultisetsSubtractsMultiplicities() {
-		XCTAssertEqual((Multiset(1, 1, 1, 2, 3) - Multiset(1, 1, 2, 4)), Multiset(1, 3))
+		XCTAssertEqual((Multiset(1, 1, 1, 2, 3) - Multiset(1, 1, 2, 4, 5)), Multiset(1, 3))
+		XCTAssertEqual((Multiset(1, 1, 2, 4, 5) - Multiset(1, 1, 1, 2, 3)), Multiset(4, 5))
 	}
 }

--- a/SetTests/MultisetCollectionTests.swift
+++ b/SetTests/MultisetCollectionTests.swift
@@ -1,0 +1,17 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+import Set
+import XCTest
+
+final class MultisetCollectionTests: XCTestCase {
+	func testIndexesElementsByMultiplicity() {
+		var multiset = Multiset<Int>()
+		multiset.insert(1)
+		multiset.insert(1)
+		multiset.insert(1)
+		multiset.insert(2)
+		multiset.insert(2)
+		multiset.insert(3)
+		XCTAssertEqual(map(multiset) { _ in () }.count, 6)
+	}
+}

--- a/SetTests/MultisetCollectionTests.swift
+++ b/SetTests/MultisetCollectionTests.swift
@@ -5,13 +5,6 @@ import XCTest
 
 final class MultisetCollectionTests: XCTestCase {
 	func testIndexesElementsByMultiplicity() {
-		var multiset = Multiset<Int>()
-		multiset.insert(1)
-		multiset.insert(1)
-		multiset.insert(1)
-		multiset.insert(2)
-		multiset.insert(2)
-		multiset.insert(3)
-		XCTAssertEqual(map(multiset) { _ in () }.count, 6)
+		XCTAssertEqual(map(Multiset(1, 1, 1, 2, 2, 3)) { _ in () }.count, 6)
 	}
 }

--- a/SetTests/MultisetCountTests.swift
+++ b/SetTests/MultisetCountTests.swift
@@ -5,10 +5,6 @@ import XCTest
 
 final class MultisetCountTests: XCTestCase {
 	func testCountSumsElementsMultiplicities() {
-		var multiset = Multiset<Int>()
-		multiset.insert(0)
-		multiset.insert(1)
-		multiset.insert(1)
-		XCTAssertEqual(multiset.count, 3)
+		XCTAssertEqual(Multiset(0, 1, 1).count, 3)
 	}
 }

--- a/SetTests/MultisetCountTests.swift
+++ b/SetTests/MultisetCountTests.swift
@@ -11,4 +11,10 @@ final class MultisetCountTests: XCTestCase {
 	func testCountOfAnElementIsItsMultiplicity() {
 		XCTAssertEqual(Multiset(0, 1, 1).count(1), 2)
 	}
+
+	func testContainsIsTrueWhenCountIsGreaterThanZero() {
+		XCTAssert(Multiset(0, 1, 1).contains(0))
+		XCTAssert(Multiset(0, 1, 1).contains(1))
+		XCTAssertFalse(Multiset(0, 1, 1).contains(2))
+	}
 }

--- a/SetTests/MultisetCountTests.swift
+++ b/SetTests/MultisetCountTests.swift
@@ -7,4 +7,8 @@ final class MultisetCountTests: XCTestCase {
 	func testCountSumsElementsMultiplicities() {
 		XCTAssertEqual(Multiset(0, 1, 1).count, 3)
 	}
+
+	func testCountOfAnElementIsItsMultiplicity() {
+		XCTAssertEqual(Multiset(0, 1, 1).count(1), 2)
+	}
 }

--- a/SetTests/MultisetCountTests.swift
+++ b/SetTests/MultisetCountTests.swift
@@ -1,0 +1,14 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+import Set
+import XCTest
+
+final class MultisetCountTests: XCTestCase {
+	func testCountSumsElementsMultiplicities() {
+		var multiset = Multiset<Int>()
+		multiset.insert(0)
+		multiset.insert(1)
+		multiset.insert(1)
+		XCTAssertEqual(multiset.count, 3)
+	}
+}

--- a/SetTests/MultisetInclusionTests.swift
+++ b/SetTests/MultisetInclusionTests.swift
@@ -17,6 +17,10 @@ final class MultisetInclusionTests: XCTestCase {
 		XCTAssert(Multiset(1, 2, 3).subset(Multiset(1, 2, 3)))
 	}
 
+	func testSubsetIncludesSmallerMultiplicities() {
+		XCTAssert(Multiset(1, 2, 3).subset(Multiset(1, 1, 2, 3)))
+	}
+
 	func testStrictSupersetIsNotSubset() {
 		XCTAssertFalse(Multiset(1, 2, 3, 4).subset(Multiset(1, 2, 3)))
 	}
@@ -37,6 +41,10 @@ final class MultisetInclusionTests: XCTestCase {
 
 	func testSupersetIncludesSelf() {
 		XCTAssert(Multiset(1, 2, 3).superset(Multiset(1, 2, 3)))
+	}
+
+	func testSupersetIncludesLargerMultiplicities() {
+		XCTAssert(Multiset(1, 1, 2, 3).superset(Multiset(1, 2, 3)))
 	}
 
 	func testStrictSubsetIsNotSuperset() {

--- a/SetTests/MultisetInclusionTests.swift
+++ b/SetTests/MultisetInclusionTests.swift
@@ -1,0 +1,50 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+import Set
+import XCTest
+
+final class MultisetInclusionTests: XCTestCase {
+	func testSubset() {
+		XCTAssert(Multiset(1).subset(Multiset(1, 2, 3)))
+	}
+
+	func testStrictSubset() {
+		XCTAssert(Multiset(1).strictSubset(Multiset(1, 2)))
+		XCTAssertFalse(Multiset(1).strictSubset(Multiset(1)))
+	}
+
+	func testSubsetIncludesSelf() {
+		XCTAssert(Multiset(1, 2, 3).subset(Multiset(1, 2, 3)))
+	}
+
+	func testStrictSupersetIsNotSubset() {
+		XCTAssertFalse(Multiset(1, 2, 3, 4).subset(Multiset(1, 2, 3)))
+	}
+
+	func testEmptySetIsAlwaysSubset() {
+		XCTAssert(Multiset().subset(Multiset<Int>()))
+		XCTAssert(Multiset().subset(Multiset(1, 2, 3)))
+	}
+
+	func testSuperset() {
+		XCTAssert(Multiset(1, 2, 3).superset(Multiset(1)))
+	}
+
+	func testStrictSuperset() {
+		XCTAssert(Multiset(1, 2).strictSuperset(Multiset(1)))
+		XCTAssertFalse(Multiset(1).strictSuperset(Multiset(1)))
+	}
+
+	func testSupersetIncludesSelf() {
+		XCTAssert(Multiset(1, 2, 3).superset(Multiset(1, 2, 3)))
+	}
+
+	func testStrictSubsetIsNotSuperset() {
+		XCTAssertFalse(Multiset(1, 2, 3).superset(Multiset(1, 2, 3, 4)))
+	}
+
+	func testAlwaysSupersetOfEmptySet() {
+		XCTAssert(Multiset<Int>().superset(Multiset()))
+		XCTAssert(Multiset(1, 2, 3).superset(Multiset()))
+	}
+}

--- a/SetTests/MultisetSequenceTests.swift
+++ b/SetTests/MultisetSequenceTests.swift
@@ -9,7 +9,7 @@ final class MultisetSequenceTests: XCTestCase {
 		multiset.insert(0)
 		multiset.insert(1)
 		multiset.insert(2)
-		XCTAssertEqual(sorted(map(multiset) { $0 }), [ 0, 1, 2 ])
+		XCTAssertEqual(sorted(Array(multiset)), [ 0, 1, 2 ])
 	}
 
 	func testGeneratorProducesElementsByMultiplicity() {

--- a/SetTests/MultisetSequenceTests.swift
+++ b/SetTests/MultisetSequenceTests.swift
@@ -5,21 +5,10 @@ import Set
 
 final class MultisetSequenceTests: XCTestCase {
 	func testGeneratorProducesEveryElement() {
-		var multiset = Multiset<Int>()
-		multiset.insert(0)
-		multiset.insert(1)
-		multiset.insert(2)
-		XCTAssertEqual(sorted(Array(multiset)), [ 0, 1, 2 ])
+		XCTAssertEqual(sorted(Array(Multiset(0, 1, 2))), [ 0, 1, 2 ])
 	}
 
 	func testGeneratorProducesElementsByMultiplicity() {
-		var multiset = Multiset<Int>()
-		multiset.insert(1)
-		multiset.insert(1)
-		multiset.insert(1)
-		multiset.insert(2)
-		multiset.insert(2)
-		multiset.insert(3)
-		XCTAssertEqual(reduce(multiset, 0, +), 10)
+		XCTAssertEqual(reduce(Multiset(1, 1, 1, 2, 2, 3), 0, +), 10)
 	}
 }

--- a/SetTests/MultisetSequenceTests.swift
+++ b/SetTests/MultisetSequenceTests.swift
@@ -1,0 +1,14 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+import XCTest
+import Set
+
+final class MultisetSequenceTests: XCTestCase {
+	func testGeneratorProducesEveryElement() {
+		var multiset = Multiset<Int>()
+		multiset.insert(0)
+		multiset.insert(1)
+		multiset.insert(2)
+		XCTAssertEqual(sorted(map(multiset) { $0 }), [ 0, 1, 2 ])
+	}
+}

--- a/SetTests/MultisetSequenceTests.swift
+++ b/SetTests/MultisetSequenceTests.swift
@@ -11,4 +11,15 @@ final class MultisetSequenceTests: XCTestCase {
 		multiset.insert(2)
 		XCTAssertEqual(sorted(map(multiset) { $0 }), [ 0, 1, 2 ])
 	}
+
+	func testGeneratorProducesElementsByMultiplicity() {
+		var multiset = Multiset<Int>()
+		multiset.insert(1)
+		multiset.insert(1)
+		multiset.insert(1)
+		multiset.insert(2)
+		multiset.insert(2)
+		multiset.insert(3)
+		XCTAssertEqual(reduce(multiset, 0, +), 10)
+	}
 }

--- a/SetTests/SetHigherOrderFunctionTests.swift
+++ b/SetTests/SetHigherOrderFunctionTests.swift
@@ -3,7 +3,7 @@
 import XCTest
 import Set
 
-class SetHigherOrderFunctionTests: XCTestCase {
+final class SetHigherOrderFunctionTests: XCTestCase {
 	func testFilter() {
 		XCTAssert(Set(1, 2, 3).filter { $0 == 2 } == Set(2))
 	}

--- a/SetTests/SetInclusionTests.swift
+++ b/SetTests/SetInclusionTests.swift
@@ -3,7 +3,7 @@
 import XCTest
 import Set
 
-class SetInclusionTests: XCTestCase {
+final class SetInclusionTests: XCTestCase {
 	func testSubset() {
 		XCTAssert(Set(1).subset(Set(1, 2, 3)))
 	}

--- a/SetTests/SetInitializerTests.swift
+++ b/SetTests/SetInitializerTests.swift
@@ -3,7 +3,7 @@
 import XCTest
 import Set
 
-class SetInitializerTests: XCTestCase {
+final class SetInitializerTests: XCTestCase {
 	func testVariadic() {
 		XCTAssert(Set(1) == Set([1]))
 		XCTAssert(Set(1, 2, 3) == Set([1, 2, 3]))

--- a/SetTests/SetOperationTests.swift
+++ b/SetTests/SetOperationTests.swift
@@ -3,7 +3,7 @@
 import XCTest
 import Set
 
-class SetOperationTests: XCTestCase {
+final class SetOperationTests: XCTestCase {
 	func testUnionAddsElementsFromBothOperands() {
 		XCTAssert(Set(1, 2, 3, 4) + Set(3, 4, 5) == Set(1, 2, 3, 4, 5))
 	}

--- a/SetTests/SetPrintableTests.swift
+++ b/SetTests/SetPrintableTests.swift
@@ -3,7 +3,7 @@
 import XCTest
 import Set
 
-class SetPrintableTests: XCTestCase, Printable, DebugPrintable {
+final class SetPrintableTests: XCTestCase, Printable, DebugPrintable {
 	func testDescription() {
 		XCTAssertEqual(Set<Int>().description, "{}")
 		XCTAssertEqual(Set(self).description, "{description}")


### PR DESCRIPTION
Fixes #36.

- [x] Tests for things like `complement` and `subset` which need to account for the counts.
- [x] Function to retrieve the count for a specific element.

We might be able to reduce some duplication with the addition of a `SetType` protocol (#2) and generic functions over it.