### PR TITLE
Fix PredicateSet example in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ difference.contains(6) // false
 
 // Special Sets
 func isInt(number: Float) -> Bool {
-	return floor(number) == number
+	return Float(Int(number)) == number
 }
 
-let Q: PredicateSet<Float> = PredicateSet { $0 as Float } // Set of all real numbers.
+let Q: PredicateSet<Float> = PredicateSet { _ in true } // Set of all real numbers.
 let Z = Q & PredicateSet { isInt($0) } // Set of all integers.
 let N = Z & PredicateSet { $0 > 0 } // Set of all natural numbers.
 


### PR DESCRIPTION
This solves two issues with the `PredicateSet` example code. First, it removes the dependency on Darwin's `floor` by sending the number through `Int` and back to `Float` to get the integer value. Second, it fixes a bug in the declaration of `Q` — `{ $0 as Float }` doesn't return a `Bool`, as required by the set's initializer.